### PR TITLE
Scaffold view example

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -1,0 +1,58 @@
+class Admin::ArticlesController < ApplicationController
+  before_action :set_article, only: [:show, :edit, :update, :destroy]
+
+  # GET /articles
+  def index
+    @articles = Article.all
+  end
+
+  # GET /articles/1
+  def show
+  end
+
+  # GET /articles/new
+  def new
+    @article = Article.new
+  end
+
+  # GET /articles/1/edit
+  def edit
+  end
+
+  # POST /articles
+  def create
+    @article = Article.new(article_params)
+
+    if @article.save
+      redirect_to [:admin, @article], notice: 'Article was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /articles/1
+  def update
+    if @article.update(article_params)
+      redirect_to [:admin, @article], notice: 'Article was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /articles/1
+  def destroy
+    @article.destroy
+    redirect_to admin_articles_url, notice: 'Article was successfully destroyed.'
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_article
+      @article = Article.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def article_params
+      params.fetch(:article, {})
+    end
+end

--- a/app/views/admin/articles/_form.html.slim
+++ b/app/views/admin/articles/_form.html.slim
@@ -1,0 +1,9 @@
+= form_for @article do |f|
+  - if @article.errors.any?
+    #error_explanation
+      h2 = "#{pluralize(@article.errors.count, "error")} prohibited this article from being saved:"
+      ul
+        - @article.errors.full_messages.each do |message|
+          li = message
+
+  .actions = f.submit

--- a/app/views/admin/articles/edit.html.slim
+++ b/app/views/admin/articles/edit.html.slim
@@ -1,0 +1,8 @@
+h1 Editing article
+
+== render 'form'
+
+=> link_to 'Show', @article
+'|
+=< link_to 'Back', admin_articles_path
+

--- a/app/views/admin/articles/index.html.slim
+++ b/app/views/admin/articles/index.html.slim
@@ -1,0 +1,19 @@
+h1 Listing articles
+
+table
+  thead
+    tr
+      th
+      th
+      th
+
+  tbody
+    - @articles.each do |article|
+      tr
+        td = link_to 'Show', article
+        td = link_to 'Edit', edit_article_path(article)
+        td = link_to 'Destroy', article, data: { confirm: 'Are you sure?' }, method: :delete
+
+br
+
+= link_to 'New Article', new_article_path

--- a/app/views/admin/articles/new.html.slim
+++ b/app/views/admin/articles/new.html.slim
@@ -1,0 +1,5 @@
+h1 New article
+
+== render 'form'
+
+= link_to 'Back', admin_articles_path

--- a/app/views/admin/articles/show.html.slim
+++ b/app/views/admin/articles/show.html.slim
@@ -1,0 +1,6 @@
+p#notice = notice
+
+
+=> link_to 'Edit', edit_article_path(@article)
+'|
+=< link_to 'Back', admin_articles_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :articles
+  end
   root 'articles#index'
   resources :articles
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/test/controllers/admin/articles_controller_test.rb
+++ b/test/controllers/admin/articles_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Admin::ArticlesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @article = articles(:one)
+  end
+
+  test "should get index" do
+    get admin_articles_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_admin_article_url
+    assert_response :success
+  end
+
+  test "should create article" do
+    assert_difference('Article.count') do
+      post admin_articles_url, params: { article: {  } }
+    end
+
+    assert_redirected_to article_url(Article.last)
+  end
+
+  test "should show article" do
+    get admin_article_url(@article)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_admin_article_url(@article)
+    assert_response :success
+  end
+
+  test "should update article" do
+    patch admin_article_url(@article), params: { article: {  } }
+    assert_redirected_to article_url(@article)
+  end
+
+  test "should destroy article" do
+    assert_difference('Article.count', -1) do
+      delete admin_article_url(@article)
+    end
+
+    assert_redirected_to admin_articles_url
+  end
+end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class ArticlesTest < ApplicationSystemTestCase
+  setup do
+    @article = articles(:one)
+  end
+
+  test "visiting the index" do
+    visit articles_url
+    assert_selector "h1", text: "Articles"
+  end
+
+  test "creating a Article" do
+    visit articles_url
+    click_on "New Article"
+
+    click_on "Create Article"
+
+    assert_text "Article was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Article" do
+    visit articles_url
+    click_on "Edit", match: :first
+
+    click_on "Update Article"
+
+    assert_text "Article was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Article" do
+    visit articles_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Article was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### Steps to reproduce
<!-- (Guidelines for creating a bug report are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->

<!-- Paste your executable test case created from one of the scripts found [here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#create-an-executable-test-case) below: -->

Generate a namespace controller with `--model-name` option. 

```shell
$ rails g model article title:string
$ rails db:migrate
$ rails g scaffold_controller admin/articles --model-name=article
```

This is a sample code.
https://github.com/kenzo-tanaka/rails_sandbox/pull/15

### Expected behavior
<!-- Tell us what should happen -->
Some paths are not what I expected.

`views/admin/articles/index.html.slim`
```slim
  tbody
    - @articles.each do |article|
      tr
        td = link_to 'Edit', edit_admin_article(article)
```

`app/views/admin/articles/show.html.slim`

```slim
=> link_to 'Edit', edit_admin_article(@article)
```


### Actual behavior
<!-- Tell us what happens instead -->

### System configuration
**Rails version**: 6.1.4
**Ruby version**: 2.6.3p62

